### PR TITLE
refactoring signer for generic interface

### DIFF
--- a/cmd/ssh_usercert_gen/main.go
+++ b/cmd/ssh_usercert_gen/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
@@ -55,7 +56,7 @@ type AppConfigFile struct {
 type RuntimeState struct {
 	Config              AppConfigFile
 	SSHCARawFileContent []byte
-	Signer              *ssh.Signer
+	Signer              *interface{}
 	ClientCAPool        *x509.CertPool
 	HostIdentity        string
 	Mutex               sync.Mutex
@@ -80,6 +81,23 @@ func exitsAndCanRead(fileName string, description string) ([]byte, error) {
 		return nil, err
 	}
 	return buffer, err
+}
+
+func getSignerFromPEMBytes(privateKey []byte) (interface{}, error) {
+	block, _ := pem.Decode(privateKey)
+	if block == nil {
+		err := errors.New("Cannot decode Private Key")
+		return "", err
+	}
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	default:
+		err := errors.New("Cannot process that key")
+		return "", err
+	}
 }
 
 func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
@@ -134,11 +152,12 @@ func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
 
 	}
 	if strings.HasPrefix(string(runtimeState.SSHCARawFileContent[:]), "-----BEGIN RSA PRIVATE KEY-----") {
-		signer, err := ssh.ParsePrivateKey(runtimeState.SSHCARawFileContent)
+		signer, err := getSignerFromPEMBytes(runtimeState.SSHCARawFileContent)
 		if err != nil {
 			log.Printf("Cannot parse Priave Key file")
 			return runtimeState, err
 		}
+
 		runtimeState.Signer = &signer
 	} else {
 		if runtimeState.ClientCAPool == nil {
@@ -239,13 +258,13 @@ const CERTGEN_PATH = "/certgen/"
 
 func (state *RuntimeState) certGenHandler(w http.ResponseWriter, r *http.Request) {
 	var signerIsNull bool
-	var signer ssh.Signer
+	var keySigner interface{}
 
 	// copy runtime singer if not nil
 	state.Mutex.Lock()
 	signerIsNull = (state.Signer == nil)
 	if !signerIsNull {
-		signer = *state.Signer
+		keySigner = *state.Signer
 	}
 	state.Mutex.Unlock()
 
@@ -253,6 +272,13 @@ func (state *RuntimeState) certGenHandler(w http.ResponseWriter, r *http.Request
 	if signerIsNull {
 		writeFailureResponse(w, http.StatusInternalServerError, "")
 		log.Printf("Signer not loaded")
+		return
+	}
+
+	signer, err := ssh.NewSignerFromKey(keySigner)
+	if err != nil {
+		writeFailureResponse(w, http.StatusInternalServerError, "")
+		log.Printf("Signer failed to load")
 		return
 	}
 
@@ -401,7 +427,7 @@ func (state *RuntimeState) secretInjectorHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	signer, err := ssh.ParsePrivateKey(plaintextBytes)
+	signer, err := getSignerFromPEMBytes(plaintextBytes)
 	if err != nil {
 		log.Printf("Cannot parse Priave Key file")
 		return

--- a/cmd/ssh_usercert_gen/main_test.go
+++ b/cmd/ssh_usercert_gen/main_test.go
@@ -7,7 +7,6 @@ import (
 	//"encoding/base64"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -147,7 +146,7 @@ func setupPasswdFile() (f *os.File, err error) {
 func TestSuccessFullSigning(t *testing.T) {
 	var state RuntimeState
 	//load signer
-	signer, err := ssh.ParsePrivateKey([]byte(testSignerPrivateKey))
+	signer, err := getSignerFromPEMBytes([]byte(testSignerPrivateKey))
 	if err != nil {
 		//log.Printf("Cannot parse Priave Key file")
 		//return runtimeState, err

--- a/cmd/ssh_usercert_gen/main_test.go
+++ b/cmd/ssh_usercert_gen/main_test.go
@@ -152,7 +152,7 @@ func TestSuccessFullSigning(t *testing.T) {
 		//return runtimeState, err
 		t.Fatal(err)
 	}
-	state.Signer = &signer
+	state.Signer = signer
 
 	passwdFile, err := setupPasswdFile()
 	if err != nil {


### PR DESCRIPTION
Refactoring of signer to use generic interface instead of ssh specific signer (this is required to simplify the upcoming x509 certgen)