### PR TITLE
Make u2f optional for certs

### DIFF
--- a/cmd/getcreds/main_test.go
+++ b/cmd/getcreds/main_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"github.com/Symantec/keymaster/lib/certgen"
+	"github.com/Symantec/keymaster/lib/webapi/v0/proto"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -121,10 +123,21 @@ func getTLSconfig() (*tls.Config, error) {
 
 const localHttpsTarget = "https://localhost:22443/"
 
+var testAllowedCertBackends = []string{proto.AuthTypePassword, proto.AuthTypeU2F}
+
 func handler(w http.ResponseWriter, r *http.Request) {
 	authCookie := http.Cookie{Name: "somename", Value: "somevalue"}
 	http.SetCookie(w, &authCookie)
-	fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
+	switch r.URL.Path {
+	case proto.LoginPath:
+		loginResponse := proto.LoginResponse{Message: "success",
+			CertAuthBackend: testAllowedCertBackends}
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(loginResponse)
+
+	default:
+		fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
+	}
 }
 
 func init() {

--- a/cmd/ssh_usercert_gen/main.go
+++ b/cmd/ssh_usercert_gen/main.go
@@ -47,13 +47,14 @@ type baseConfig struct {
 	TLSCertFilename string `yaml:"tls_cert_filename"`
 	TLSKeyFilename  string `yaml:"tls_key_filename"`
 	//UserAuth         string
-	RequiredAuthForCert string `yaml:"required_auth_for_cert"`
-	SSHCAFilename       string `yaml:"ssh_ca_filename"`
-	HtpasswdFilename    string `yaml:"htpasswd_filename"`
-	ClientCAFilename    string `yaml:"client_ca_filename"`
-	HostIdentity        string `yaml:"host_identity"`
-	KerberosRealm       string `yaml:"kerberos_realm"`
-	DataDirectory       string `yaml:"data_directory"`
+	RequiredAuthForCert         string   `yaml:"required_auth_for_cert"`
+	SSHCAFilename               string   `yaml:"ssh_ca_filename"`
+	HtpasswdFilename            string   `yaml:"htpasswd_filename"`
+	ClientCAFilename            string   `yaml:"client_ca_filename"`
+	HostIdentity                string   `yaml:"host_identity"`
+	KerberosRealm               string   `yaml:"kerberos_realm"`
+	DataDirectory               string   `yaml:"data_directory"`
+	AllowedAuthBackendsForCerts []string `yaml:"allowed_auth_backends_for_certs"`
 }
 
 type LdapConfig struct {
@@ -912,8 +913,24 @@ func (state *RuntimeState) loginHandler(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 	}
+
+	// Compute the cert prefs
+	var certBackends []string
+	for _, certPref := range state.Config.Base.AllowedAuthBackendsForCerts {
+		if certPref == proto.AuthTypePassword {
+			certBackends = append(certBackends, proto.AuthTypePassword)
+		}
+		if certPref == proto.AuthTypeU2F {
+			certBackends = append(certBackends, proto.AuthTypeU2F)
+		}
+	}
+	if len(certBackends) == 0 {
+		certBackends = append(certBackends, proto.AuthTypeU2F)
+	}
+
+	// TODO: The cert backend should depend also on per user preferences.
 	loginResponse := proto.LoginResponse{Message: "success",
-		CertAuthBackend: []string{proto.AuthTypePassword, proto.AuthTypeU2F}}
+		CertAuthBackend: certBackends}
 	switch returnAcceptType {
 	case "text/html":
 		http.Redirect(w, r, profilePath, 302)


### PR DESCRIPTION
This is the continuation of the u2f change. This ends it by making optional and making the minimal selection be part of the configuration for the service.