### PR TITLE
Move mgmt to separate port

### DIFF
--- a/cmd/ssh_usercert_gen/config.go
+++ b/cmd/ssh_usercert_gen/config.go
@@ -26,6 +26,7 @@ import (
 
 type baseConfig struct {
 	HttpAddress     string `yaml:"http_address"`
+	AdminAddress    string `yaml:"admin_address"`
 	TLSCertFilename string `yaml:"tls_cert_filename"`
 	TLSKeyFilename  string `yaml:"tls_key_filename"`
 	//RequiredAuthForCert         string   `yaml:"required_auth_for_cert"`

--- a/cmd/ssh_usercert_gen/config.go
+++ b/cmd/ssh_usercert_gen/config.go
@@ -92,6 +92,7 @@ func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
 	runtimeState.authCookie = make(map[string]authInfo)
 	//runtimeState.userProfile = make(map[string]userProfile)
 	runtimeState.pendingOauth2 = make(map[string]pendingAuth2Request)
+	runtimeState.SignerIsReady = make(chan bool, 1)
 
 	//verify config
 	if len(runtimeState.Config.Base.HostIdentity) > 0 {
@@ -158,6 +159,7 @@ func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
 		// Assignmet of signer MUST be the last operation after
 		// all error checks
 		runtimeState.Signer = signer
+		runtimeState.SignerIsReady <- true
 
 	} else {
 		if runtimeState.ClientCAPool == nil {

--- a/cmd/ssh_usercert_gen/main.go
+++ b/cmd/ssh_usercert_gen/main.go
@@ -1346,28 +1346,26 @@ func main() {
 		log.Printf("After load verify")
 	}
 
-	serviceMux := http.NewServeMux()
-
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", prometheus.Handler())
 	http.HandleFunc(secretInjectorPath, runtimeState.secretInjectorHandler)
 
-	serviceMux.HandleFunc(certgenPath, runtimeState.certGenHandler)
-	serviceMux.HandleFunc(publicPath, runtimeState.publicPathHandler)
-	serviceMux.HandleFunc(proto.LoginPath, runtimeState.loginHandler)
-	serviceMux.HandleFunc(logoutPath, runtimeState.logoutHandler)
+	http.HandleFunc(certgenPath, runtimeState.certGenHandler)
+	http.HandleFunc(publicPath, runtimeState.publicPathHandler)
+	http.HandleFunc(proto.LoginPath, runtimeState.loginHandler)
+	http.HandleFunc(logoutPath, runtimeState.logoutHandler)
 
-	serviceMux.HandleFunc(profilePath, runtimeState.profileHandler)
+	http.HandleFunc(profilePath, runtimeState.profileHandler)
 
 	staticFilesPath := filepath.Join(runtimeState.Config.Base.SharedDataDirectory, "static_files")
-	serviceMux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticFilesPath))))
-	serviceMux.HandleFunc(u2fRegustisterRequestPath, runtimeState.u2fRegisterRequest)
-	serviceMux.HandleFunc(u2fRegisterRequesponsePath, runtimeState.u2fRegisterResponse)
-	serviceMux.HandleFunc(u2fSignRequestPath, runtimeState.u2fSignRequest)
-	serviceMux.HandleFunc(u2fSignResponsePath, runtimeState.u2fSignResponse)
-	serviceMux.HandleFunc(u2fTokenManagementPath, runtimeState.u2fTokenManagerHandler)
-	serviceMux.HandleFunc(oauth2LoginBeginPath, runtimeState.oauth2DoRedirectoToProviderHandler)
-	serviceMux.HandleFunc(redirectPath, runtimeState.oauth2RedirectPathHandler)
+	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticFilesPath))))
+	http.HandleFunc(u2fRegustisterRequestPath, runtimeState.u2fRegisterRequest)
+	http.HandleFunc(u2fRegisterRequesponsePath, runtimeState.u2fRegisterResponse)
+	http.HandleFunc(u2fSignRequestPath, runtimeState.u2fSignRequest)
+	http.HandleFunc(u2fSignResponsePath, runtimeState.u2fSignResponse)
+	http.HandleFunc(u2fTokenManagementPath, runtimeState.u2fTokenManagerHandler)
+	http.HandleFunc(oauth2LoginBeginPath, runtimeState.oauth2DoRedirectoToProviderHandler)
+	http.HandleFunc(redirectPath, runtimeState.oauth2RedirectPathHandler)
 
 	cfg := &tls.Config{
 		ClientCAs:                runtimeState.ClientCAPool,
@@ -1382,7 +1380,6 @@ func main() {
 	}
 	adminSrv := &http.Server{
 		Addr:         runtimeState.Config.Base.AdminAddress,
-		Handler:      http.DefaultServeMux,
 		TLSConfig:    cfg,
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 	}
@@ -1403,7 +1400,6 @@ func main() {
 
 	serviceSrv := &http.Server{
 		Addr:         runtimeState.Config.Base.HttpAddress,
-		Handler:      serviceMux,
 		TLSConfig:    cfg,
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 	}

--- a/cmd/ssh_usercert_gen/main.go
+++ b/cmd/ssh_usercert_gen/main.go
@@ -1338,25 +1338,28 @@ func main() {
 		log.Printf("After load verify")
 	}
 
+	serviceMux := http.NewServeMux()
+
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", prometheus.Handler())
 	http.HandleFunc(secretInjectorPath, runtimeState.secretInjectorHandler)
-	http.HandleFunc(certgenPath, runtimeState.certGenHandler)
-	http.HandleFunc(publicPath, runtimeState.publicPathHandler)
-	http.HandleFunc(proto.LoginPath, runtimeState.loginHandler)
-	http.HandleFunc(logoutPath, runtimeState.logoutHandler)
 
-	http.HandleFunc(profilePath, runtimeState.profileHandler)
+	serviceMux.HandleFunc(certgenPath, runtimeState.certGenHandler)
+	serviceMux.HandleFunc(publicPath, runtimeState.publicPathHandler)
+	serviceMux.HandleFunc(proto.LoginPath, runtimeState.loginHandler)
+	serviceMux.HandleFunc(logoutPath, runtimeState.logoutHandler)
+
+	serviceMux.HandleFunc(profilePath, runtimeState.profileHandler)
 
 	staticFilesPath := filepath.Join(runtimeState.Config.Base.SharedDataDirectory, "static_files")
-	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticFilesPath))))
-	http.HandleFunc(u2fRegustisterRequestPath, runtimeState.u2fRegisterRequest)
-	http.HandleFunc(u2fRegisterRequesponsePath, runtimeState.u2fRegisterResponse)
-	http.HandleFunc(u2fSignRequestPath, runtimeState.u2fSignRequest)
-	http.HandleFunc(u2fSignResponsePath, runtimeState.u2fSignResponse)
-	http.HandleFunc(u2fTokenManagementPath, runtimeState.u2fTokenManagerHandler)
-	http.HandleFunc(oauth2LoginBeginPath, runtimeState.oauth2DoRedirectoToProviderHandler)
-	http.HandleFunc(redirectPath, runtimeState.oauth2RedirectPathHandler)
+	serviceMux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(staticFilesPath))))
+	serviceMux.HandleFunc(u2fRegustisterRequestPath, runtimeState.u2fRegisterRequest)
+	serviceMux.HandleFunc(u2fRegisterRequesponsePath, runtimeState.u2fRegisterResponse)
+	serviceMux.HandleFunc(u2fSignRequestPath, runtimeState.u2fSignRequest)
+	serviceMux.HandleFunc(u2fSignResponsePath, runtimeState.u2fSignResponse)
+	serviceMux.HandleFunc(u2fTokenManagementPath, runtimeState.u2fTokenManagerHandler)
+	serviceMux.HandleFunc(oauth2LoginBeginPath, runtimeState.oauth2DoRedirectoToProviderHandler)
+	serviceMux.HandleFunc(redirectPath, runtimeState.oauth2RedirectPathHandler)
 
 	cfg := &tls.Config{
 		ClientCAs:                runtimeState.ClientCAPool,
@@ -1369,13 +1372,30 @@ func main() {
 			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 		},
 	}
-	srv := &http.Server{
+	adminSrv := &http.Server{
+		Addr:         runtimeState.Config.Base.AdminAddress,
+		Handler:      http.DefaultServeMux,
+		TLSConfig:    cfg,
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
+	}
+	go func(msg string) {
+		err := adminSrv.ListenAndServeTLS(
+			runtimeState.Config.Base.TLSCertFilename,
+			runtimeState.Config.Base.TLSKeyFilename)
+		if err != nil {
+			panic(err)
+		}
+
+	}("done")
+
+	serviceSrv := &http.Server{
 		Addr:         runtimeState.Config.Base.HttpAddress,
+		Handler:      serviceMux,
 		TLSConfig:    cfg,
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 	}
 
-	err = srv.ListenAndServeTLS(
+	err = serviceSrv.ListenAndServeTLS(
 		runtimeState.Config.Base.TLSCertFilename,
 		runtimeState.Config.Base.TLSKeyFilename)
 	if err != nil {

--- a/cmd/ssh_usercert_gen/main_test.go
+++ b/cmd/ssh_usercert_gen/main_test.go
@@ -366,6 +366,7 @@ func TestInjectingSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 	state.SSHCARawFileContent = []byte(encryptedTestSignerPrivateKey)
+	state.SignerIsReady = make(chan bool, 1)
 
 	defer os.Remove(passwdFile.Name()) // clean up
 	state.Config.Base.HtpasswdFilename = passwdFile.Name()

--- a/lib/authutil/authutil_test.go
+++ b/lib/authutil/authutil_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"testing"
+	"time"
 )
 
 /* To generate certs, I used all data here should expire around Jan 1 2037:
@@ -174,6 +175,10 @@ func init() {
 			conn.Close()
 		}
 	}(ln)
+	// On single core systems we needed to ensure that the server is started before
+	// we create other testing goroutines. By sleeping we yield the cpu and allow
+	// ListenAndServe to progress
+	time.Sleep(20 * time.Millisecond)
 }
 
 func TestCheckHtpasswdUserPasswordSuccess(t *testing.T) {


### PR DESCRIPTION
In order to have simple HA, the service port should be different from the admin port (this way there is not even a terminating tcp reponse, making services fail over to other keymaster servers).