### PR TITLE
Remove logger and Version global variables.

### DIFF
--- a/cmd/keymaster/main.go
+++ b/cmd/keymaster/main.go
@@ -58,8 +58,11 @@ type AppConfigFile struct {
 	Base baseConfig
 }
 
+const (
+	Version = "No version provided"
+)
+
 var (
-	Version        = "No version provided"
 	configFilename = flag.String("config", filepath.Join(os.Getenv("HOME"), ".keymaster", "client_config.yml"), "The filename of the configuration")
 	rootCAFilename = flag.String("rootCAFilename", "", "(optional) name for using non OS root CA to verify TLS connections")
 	configHost     = flag.String("configHost", "", "Get a bootstrap config from this host")
@@ -68,8 +71,6 @@ var (
 	checkDevices   = flag.Bool("checkDevices", false, "CheckU2F devices in your system")
 	noU2F          = flag.Bool("noU2F", false, "Don't use U2F as second factor")
 	noVIPAccess    = flag.Bool("noVIPAccess", false, "Don't use VIPAccess as second factor")
-
-	logger log.DebugLogger
 )
 
 func getUserHomeDir(usr *user.User) (string, error) {
@@ -79,7 +80,9 @@ func getUserHomeDir(usr *user.User) (string, error) {
 
 // generateKeyPair uses internal golang functions to be portable
 // mostly comes from: http://stackoverflow.com/questions/21151714/go-generate-an-ssh-public-key
-func genKeyPair(privateKeyPath string, identity string) (crypto.Signer, string, error) {
+func genKeyPair(
+	privateKeyPath string, identity string, logger log.Logger) (
+	crypto.Signer, string, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, RSAKeySize)
 	if err != nil {
 		return nil, "", err
@@ -177,7 +180,7 @@ func createKeyBodyRequest(method, urlStr, filedata string) (*http.Request, error
 	return req, nil
 }
 
-func doCertRequest(client *http.Client, authCookies []*http.Cookie, url, filedata string) ([]byte, error) {
+func doCertRequest(client *http.Client, authCookies []*http.Cookie, url, filedata string, logger log.Logger) ([]byte, error) {
 
 	req, err := createKeyBodyRequest("POST", url, filedata)
 	if err != nil {
@@ -202,7 +205,7 @@ func doCertRequest(client *http.Client, authCookies []*http.Cookie, url, filedat
 
 }
 
-func checkU2FDevices() {
+func checkU2FDevices(logger log.Logger) {
 	// TODO: move this to initialization code, ans pass the device list to this function?
 	// or maybe pass the token?...
 	devices, err := u2fhid.Devices()
@@ -227,7 +230,11 @@ func checkU2FDevices() {
 
 }
 
-func doU2FAuthenticate(client *http.Client, authCookies []*http.Cookie, baseURL string) error {
+func doU2FAuthenticate(
+	client *http.Client,
+	authCookies []*http.Cookie,
+	baseURL string,
+	logger log.DebugLogger) error {
 	logger.Printf("top of doU2fAuthenticate")
 	url := baseURL + "/u2f/SignRequest"
 	signRequest, err := http.NewRequest("GET", url, nil)
@@ -403,7 +410,11 @@ func getParseURLEnvVariable(name string) (*url.URL, error) {
 	return envUrl, nil
 }
 
-func doVIPAuthenticate(client *http.Client, authCookies []*http.Cookie, baseURL string) error {
+func doVIPAuthenticate(
+	client *http.Client,
+	authCookies []*http.Cookie,
+	baseURL string,
+	logger log.DebugLogger) error {
 	logger.Printf("top of doVIPAuthenticate")
 
 	// Read VIP token from client
@@ -482,7 +493,14 @@ func getHttpClient(tlsConfig *tls.Config) (*http.Client, error) {
 	return client, nil
 }
 
-func getCertsFromServer(signer crypto.Signer, userName string, password []byte, baseUrl string, tlsConfig *tls.Config, skip2fa bool) (sshCert []byte, x509Cert []byte, err error) {
+func getCertsFromServer(
+	signer crypto.Signer,
+	userName string,
+	password []byte,
+	baseUrl string,
+	tlsConfig *tls.Config,
+	skip2fa bool,
+	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, err error) {
 	//First Do Login
 	client, err := getHttpClient(tlsConfig)
 	if err != nil {
@@ -565,7 +583,8 @@ func getCertsFromServer(signer crypto.Signer, userName string, password []byte, 
 			}
 			if len(devices) > 0 {
 
-				err = doU2FAuthenticate(client, loginResp.Cookies(), baseUrl)
+				err = doU2FAuthenticate(
+					client, loginResp.Cookies(), baseUrl, logger)
 				if err != nil {
 
 					return nil, nil, err
@@ -575,7 +594,8 @@ func getCertsFromServer(signer crypto.Signer, userName string, password []byte, 
 		}
 
 		if allowVIP && !successful2fa {
-			err = doVIPAuthenticate(client, loginResp.Cookies(), baseUrl)
+			err = doVIPAuthenticate(
+				client, loginResp.Cookies(), baseUrl, logger)
 			if err != nil {
 
 				return nil, nil, err
@@ -601,7 +621,12 @@ func getCertsFromServer(signer crypto.Signer, userName string, password []byte, 
 	pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: derKey}))
 
 	// TODO: urlencode the userName
-	x509Cert, err = doCertRequest(client, loginResp.Cookies(), baseUrl+"/certgen/"+userName+"?type=x509", pemKey)
+	x509Cert, err = doCertRequest(
+		client,
+		loginResp.Cookies(),
+		baseUrl+"/certgen/"+userName+"?type=x509",
+		pemKey,
+		logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -613,7 +638,12 @@ func getCertsFromServer(signer crypto.Signer, userName string, password []byte, 
 		return nil, nil, err
 	}
 	sshAuthFile := string(ssh.MarshalAuthorizedKey(sshPub))
-	sshCert, err = doCertRequest(client, loginResp.Cookies(), baseUrl+"/certgen/"+userName+"?type=ssh", sshAuthFile)
+	sshCert, err = doCertRequest(
+		client,
+		loginResp.Cookies(),
+		baseUrl+"/certgen/"+userName+"?type=ssh",
+		sshAuthFile,
+		logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -621,13 +651,21 @@ func getCertsFromServer(signer crypto.Signer, userName string, password []byte, 
 	return sshCert, x509Cert, nil
 }
 
-func getCertFromTargetUrls(signer crypto.Signer, userName string, password []byte, targetUrls []string, rootCAs *x509.CertPool, skipu2f bool) (sshCert []byte, x509Cert []byte, err error) {
+func getCertFromTargetUrls(
+	signer crypto.Signer,
+	userName string,
+	password []byte,
+	targetUrls []string,
+	rootCAs *x509.CertPool,
+	skipu2f bool,
+	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, err error) {
 	success := false
 	tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 
 	for _, baseUrl := range targetUrls {
 		logger.Printf("attempting to target '%s' for '%s'\n", baseUrl, userName)
-		sshCert, x509Cert, err = getCertsFromServer(signer, userName, password, baseUrl, tlsConfig, skipu2f)
+		sshCert, x509Cert, err = getCertsFromServer(
+			signer, userName, password, baseUrl, tlsConfig, skipu2f, logger)
 		if err != nil {
 			logger.Println(err)
 			continue
@@ -656,7 +694,11 @@ func getUserCreds(userName string) (password []byte, err error) {
 
 const hostConfigPath = "/public/clientConfig"
 
-func getConfigFromHost(configFilename string, hostname string, rootCAs *x509.CertPool) error {
+func getConfigFromHost(
+	configFilename string,
+	hostname string,
+	rootCAs *x509.CertPool,
+	logger log.Logger) error {
 	tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 	client, err := getHttpClient(tlsConfig)
 	if err != nil {
@@ -695,10 +737,10 @@ func Usage() {
 func main() {
 	flag.Usage = Usage
 	flag.Parse()
-	logger = cmdlogger.New()
+	logger := cmdlogger.New()
 
 	if *checkDevices {
-		checkU2FDevices()
+		checkU2FDevices(logger)
 		return
 	}
 
@@ -742,13 +784,14 @@ func main() {
 	}
 
 	if len(*configHost) > 1 {
-		err = getConfigFromHost(*configFilename, *configHost, rootCAs)
+		err = getConfigFromHost(*configFilename, *configHost, rootCAs, logger)
 		if err != nil {
 			logger.Fatal(err)
 		}
 	} else if len(defaultConfigHost) > 1 { // if there is a configHost AND there is NO config file, create one
 		if _, err := os.Stat(*configFilename); os.IsNotExist(err) {
-			err = getConfigFromHost(*configFilename, defaultConfigHost, rootCAs)
+			err = getConfigFromHost(
+				*configFilename, defaultConfigHost, rootCAs, logger)
 			if err != nil {
 				logger.Fatal(err)
 			}
@@ -777,7 +820,8 @@ func main() {
 	}
 
 	tempPrivateKeyPath := filepath.Join(homeDir, DefaultKeysLocation, "keymaster-temp")
-	signer, tempPublicKeyPath, err := genKeyPair(tempPrivateKeyPath, userName+"@keymaster")
+	signer, tempPublicKeyPath, err := genKeyPair(
+		tempPrivateKeyPath, userName+"@keymaster", logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
@@ -789,8 +833,14 @@ func main() {
 		logger.Fatal(err)
 	}
 
-	sshCert, x509Cert, err := getCertFromTargetUrls(signer, userName,
-		password, strings.Split(config.Base.Gen_Cert_URLS, ","), rootCAs, false)
+	sshCert, x509Cert, err := getCertFromTargetUrls(
+		signer,
+		userName,
+		password,
+		strings.Split(config.Base.Gen_Cert_URLS, ","),
+		rootCAs,
+		false,
+		logger)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/cmd/keymaster/main_test.go
+++ b/cmd/keymaster/main_test.go
@@ -7,11 +7,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"github.com/Symantec/Dominator/lib/log/debuglogger"
+	"github.com/Symantec/Dominator/lib/log/testlogger"
 	"github.com/Symantec/keymaster/lib/certgen"
 	"github.com/Symantec/keymaster/lib/webapi/v0/proto"
 	"io/ioutil"
-	stdlog "log"
 	"net/http"
 	"os"
 	"os/user"
@@ -143,7 +142,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func init() {
-	logger = debuglogger.New(stdlog.New(os.Stderr, "", stdlog.LstdFlags))
 	tlsConfig, _ := getTLSconfig()
 	//_, _ = tls.Listen("tcp", ":11443", config)
 	srv := &http.Server{
@@ -163,7 +161,7 @@ func TestGenKeyPairSuccess(t *testing.T) {
 
 	defer os.Remove(tmpfile.Name()) // clean up
 
-	_, _, err = genKeyPair(tmpfile.Name(), "test")
+	_, _, err = genKeyPair(tmpfile.Name(), "test", testlogger.New(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +177,7 @@ func TestGenKeyPairSuccess(t *testing.T) {
 }
 
 func TestGenKeyPairFailNoPerms(t *testing.T) {
-	_, _, err := genKeyPair("/proc/something", "test")
+	_, _, err := genKeyPair("/proc/something", "test", testlogger.New(t))
 	if err == nil {
 		t.Logf("Should have failed")
 		t.Fatal(err)
@@ -285,7 +283,14 @@ func TestGetCertFromTargetUrlsSuccessOneURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	skipu2f := true
-	_, _, err = getCertFromTargetUrls(privateKey, "username", []byte("password"), []string{localHttpsTarget}, certPool, skipu2f) //(cert []byte, err error)
+	_, _, err = getCertFromTargetUrls(
+		privateKey,
+		"username",
+		[]byte("password"),
+		[]string{localHttpsTarget},
+		certPool,
+		skipu2f,
+		testlogger.New(t)) //(cert []byte, err error)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +302,14 @@ func TestGetCertFromTargetUrlsFailUntrustedCA(t *testing.T) {
 		t.Fatal(err)
 	}
 	skipu2f := true
-	_, _, err = getCertFromTargetUrls(privateKey, "username", []byte("password"), []string{localHttpsTarget}, nil, skipu2f)
+	_, _, err = getCertFromTargetUrls(
+		privateKey,
+		"username",
+		[]byte("password"),
+		[]string{localHttpsTarget},
+		nil,
+		skipu2f,
+		testlogger.New(t))
 	if err == nil {
 		t.Fatal("Should have failed to connect untrusted CA")
 	}


### PR DESCRIPTION
Remove logger global variable by creating a logger in main and pass it around as a parameter when needed. Made Version global variable a constant.  Don't know whether or not we should get rid of the defaultConfigHost global variable as it is injected by the build process. Good news is defaultConfigHost is only used in the main() function so it at least has limited scope.