### PR TITLE
Add admin role to profile page.

### DIFF
--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -45,6 +45,7 @@ type baseConfig struct {
 	HideStandardLogin           bool     `yaml:"hide_standard_login"`
 	AllowedAuthBackendsForCerts []string `yaml:"allowed_auth_backends_for_certs"`
 	AllowedAuthBackendsForWebUI []string `yaml:"allowed_auth_backends_for_webui"`
+	Admins                      []string `yaml:"admins"`
 }
 
 type LdapConfig struct {


### PR DESCRIPTION
If logged in user is one of the listed admins in config.yml, they can see any
user's profile by going to /profile/name_of_user.