### PR TITLE
Add resiliancy to ldap failures part2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 # github.com/flynn/hid is broken on go1.9 on MacOS X, so pin to go1.8.
 go:
-    - 1.8
+    - 1.8.3
 
 os:
     - linux

--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -53,6 +53,7 @@ type baseConfig struct {
 type LdapConfig struct {
 	Bind_Pattern     string
 	LDAP_Target_URLs string
+	DisableAuthCache bool `yaml:"disable_auth_cache"`
 }
 
 type UserInfoLDAPSource struct {
@@ -356,10 +357,14 @@ func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
 	}
 	if len(runtimeState.Config.Ldap.LDAP_Target_URLs) > 0 {
 		const timeoutSecs = 3
+		pwdCache := &runtimeState
+		if runtimeState.Config.Ldap.DisableAuthCache {
+			pwdCache = nil
+		}
 		runtimeState.passwordChecker, err = ldap.New(
 			strings.Split(runtimeState.Config.Ldap.LDAP_Target_URLs, ","),
 			[]string{runtimeState.Config.Ldap.Bind_Pattern},
-			timeoutSecs, nil, &runtimeState,
+			timeoutSecs, nil, pwdCache,
 			logger)
 		if err != nil {
 			return runtimeState, err

--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -359,7 +359,7 @@ func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
 		runtimeState.passwordChecker, err = ldap.New(
 			strings.Split(runtimeState.Config.Ldap.LDAP_Target_URLs, ","),
 			[]string{runtimeState.Config.Ldap.Bind_Pattern},
-			timeoutSecs, nil,
+			timeoutSecs, nil, &runtimeState,
 			logger)
 		if err != nil {
 			return runtimeState, err

--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -51,9 +51,9 @@ type baseConfig struct {
 }
 
 type LdapConfig struct {
-	Bind_Pattern         string
-	LDAP_Target_URLs     string
-	DisablePasswordCache bool `yaml:"disable_password_cache"`
+	BindPattern          string `yaml:"bind_pattern"`
+	LDAPTargetURLs       string `yaml:"ldap_target_urls"`
+	DisablePasswordCache bool   `yaml:"disable_password_cache"`
 }
 
 type UserInfoLDAPSource struct {
@@ -355,15 +355,15 @@ func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
 			return runtimeState, err
 		}
 	}
-	if len(runtimeState.Config.Ldap.LDAP_Target_URLs) > 0 {
+	if len(runtimeState.Config.Ldap.LDAPTargetURLs) > 0 {
 		const timeoutSecs = 3
 		pwdCache := &runtimeState
 		if runtimeState.Config.Ldap.DisablePasswordCache {
 			pwdCache = nil
 		}
 		runtimeState.passwordChecker, err = ldap.New(
-			strings.Split(runtimeState.Config.Ldap.LDAP_Target_URLs, ","),
-			[]string{runtimeState.Config.Ldap.Bind_Pattern},
+			strings.Split(runtimeState.Config.Ldap.LDAPTargetURLs, ","),
+			[]string{runtimeState.Config.Ldap.BindPattern},
 			timeoutSecs, nil, pwdCache,
 			logger)
 		if err != nil {

--- a/cmd/keymasterd/config.go
+++ b/cmd/keymasterd/config.go
@@ -51,9 +51,9 @@ type baseConfig struct {
 }
 
 type LdapConfig struct {
-	Bind_Pattern     string
-	LDAP_Target_URLs string
-	DisableAuthCache bool `yaml:"disable_auth_cache"`
+	Bind_Pattern         string
+	LDAP_Target_URLs     string
+	DisablePasswordCache bool `yaml:"disable_password_cache"`
 }
 
 type UserInfoLDAPSource struct {
@@ -358,7 +358,7 @@ func loadVerifyConfigFile(configFilename string) (RuntimeState, error) {
 	if len(runtimeState.Config.Ldap.LDAP_Target_URLs) > 0 {
 		const timeoutSecs = 3
 		pwdCache := &runtimeState
-		if runtimeState.Config.Ldap.DisableAuthCache {
+		if runtimeState.Config.Ldap.DisablePasswordCache {
 			pwdCache = nil
 		}
 		runtimeState.passwordChecker, err = ldap.New(

--- a/cmd/keymasterd/jwt.go
+++ b/cmd/keymasterd/jwt.go
@@ -139,17 +139,13 @@ func (state *RuntimeState) getStorageDataFromStorageStringDataJWT(serializedToke
 		logger.Printf("err=%s", err)
 		return rvalue, err
 	}
-	//At this stage is now crypto verified, now is time to verify sane values
+	// At this stage is now crypto verified (data actually comes from a valid signer),
+	// Now is time to do semantic validation
 	issuer := state.idpGetIssuer()
 	if inboundJWT.Issuer != issuer || inboundJWT.TokenType != "storage_data" ||
 		inboundJWT.NotBefore > time.Now().Unix() {
 		err = errors.New("invalid JWT values")
 		return rvalue, err
 	}
-	/*
-		rvalue.Username = inboundJWT.Subject
-		rvalue.AuthType = inboundJWT.AuthType
-		rvalue.ExpiresAt = time.Unix(inboundJWT.Expiration, 0)
-	*/
 	return inboundJWT, nil
 }

--- a/cmd/keymasterd/jwt.go
+++ b/cmd/keymasterd/jwt.go
@@ -139,7 +139,7 @@ func (state *RuntimeState) getStorageDataFromStorageStringDataJWT(serializedToke
 		logger.Printf("err=%s", err)
 		return rvalue, err
 	}
-	// At this stage is now crypto verified (data actually comes from a valid signer),
+	// At this stage crypto has been verified (data actually comes from a valid signer),
 	// Now is time to do semantic validation
 	issuer := state.idpGetIssuer()
 	if inboundJWT.Issuer != issuer || inboundJWT.TokenType != "storage_data" ||

--- a/cmd/keymasterd/main.go
+++ b/cmd/keymasterd/main.go
@@ -73,6 +73,18 @@ type authInfoJWT struct {
 	AuthType   int      `json:"auth_type"`
 }
 
+type storageStringDataJWT struct {
+	Issuer     string   `json:"iss,omitempty"`
+	Subject    string   `json:"sub,omitempty"`
+	Audience   []string `json:"aud,omitempty"`
+	NotBefore  int64    `json:"nbf,omitempty"`
+	Expiration int64    `json:"exp"`
+	IssuedAt   int64    `json:"iat,omitempty"`
+	TokenType  string   `json:"token_type"`
+	DataType   int      `json:"data_type"`
+	Data       string   `json:"data"`
+}
+
 type u2fAuthData struct {
 	Enabled      bool
 	CreatedAt    time.Time

--- a/cmd/keymasterd/main.go
+++ b/cmd/keymasterd/main.go
@@ -286,7 +286,7 @@ func checkUserPassword(username string, password string, config AppConfigFile, p
 	if passwordChecker != nil {
 		logger.Debugf(3, "checking auth with passwordChecker")
 		isLDAP := false
-		if len(config.Ldap.LDAP_Target_URLs) > 0 {
+		if len(config.Ldap.LDAPTargetURLs) > 0 {
 			isLDAP = true
 		}
 

--- a/cmd/keymasterd/storage.go
+++ b/cmd/keymasterd/storage.go
@@ -211,6 +211,11 @@ func copyDBIntoSQLite(source, destination *sql.DB, destinationType string) error
 		return err
 	}
 
+	err = tx.Commit()
+	if err != nil {
+		logger.Printf("err='%s'", err)
+		return err
+	}
 	return nil
 }
 

--- a/cmd/keymasterd/storage.go
+++ b/cmd/keymasterd/storage.go
@@ -73,16 +73,14 @@ func initDBPostgres(state *RuntimeState) (err error) {
 		sqlStmt := `create table if not exists user_profile (id serial not null primary key, username text unique, profile_data bytea);`
 		_, err = state.db.Exec(sqlStmt)
 		if err != nil {
-			logger.Printf("%q: %s\n", err, sqlStmt)
+			logger.Printf("init postgres err: %s: %q\n", err, sqlStmt)
 			return err
 		}
 		sqlStmt = `create table if not exists expiring_signed_user_data(id serial not null primary key, username text not null, jws_data text not null, type integer not null, expiration_epoch integer not null, update_epoch integer not null, UNIQUE(username,type));`
 		_, err = state.db.Exec(sqlStmt)
 		if err != nil {
-			logger.Printf("%q: %s\n", err, sqlStmt)
+			logger.Printf("init postgres err: %s: %q\n", err, sqlStmt)
 			return err
-		} else {
-			logger.Printf("created table?")
 		}
 	}
 
@@ -104,10 +102,10 @@ var sqliteinitializationStatements = []string{
 
 func initializeSQLitetables(db *sql.DB) error {
 	for _, sqlStmt := range sqliteinitializationStatements {
-		logger.Debugf(2, "initializing sqlite, statement =%s", sqlStmt)
+		logger.Debugf(2, "initializing sqlite, statement =%q", sqlStmt)
 		_, err := db.Exec(sqlStmt)
 		if err != nil {
-			logger.Printf("%q: %s\n", err, sqlStmt)
+			logger.Printf("%s: %q\n", err, sqlStmt)
 			return err
 		}
 	}
@@ -490,7 +488,6 @@ func (state *RuntimeState) GetSigned(username string, dataType int) (bool, strin
 	stmtText := getSignedUserDataStmt[state.dbType]
 	stmt, err := state.db.Prepare(stmtText)
 	if err != nil {
-		logger.Print("Error Preparing statement")
 		logger.Fatal(err)
 	}
 	defer stmt.Close()
@@ -509,8 +506,7 @@ func (state *RuntimeState) GetSigned(username string, dataType int) (bool, strin
 		return false, "", err
 	}
 	if storageJWT.Subject != username {
-		err := errors.New("inconsistent data coming from DB")
-		return false, "", err
+		return false, "", errors.New("inconsistent data coming from DB")
 	}
 
 	return true, storageJWT.Data, nil

--- a/lib/authutil/authutil.go
+++ b/lib/authutil/authutil.go
@@ -28,7 +28,7 @@ import (
 // We will use slightly bigger values:
 
 const argon2t = 40
-const argon2m = 17
+const argon2m = 18
 const argon2p = 2
 const argon2l = 32
 

--- a/lib/authutil/authutil.go
+++ b/lib/authutil/authutil.go
@@ -28,7 +28,7 @@ import (
 // We will use slightly bigger values:
 
 const argon2t = 40
-const argon2m = 18
+const argon2m = 20
 const argon2p = 2
 const argon2l = 32
 

--- a/lib/pwauth/ldap/api.go
+++ b/lib/pwauth/ldap/api.go
@@ -2,9 +2,11 @@ package ldap
 
 import (
 	"crypto/x509"
-	"github.com/Symantec/Dominator/lib/log"
 	"net/url"
 	"time"
+
+	"github.com/Symantec/Dominator/lib/log"
+	"github.com/Symantec/keymaster/lib/simplestorage"
 )
 
 type cacheCredentialEntry struct {
@@ -19,12 +21,13 @@ type PasswordAuthenticator struct {
 	rootCAs            *x509.CertPool
 	logger             log.DebugLogger
 	expirationDuration time.Duration
+	storage            simplestorage.SimpleStore
 	cachedCredentials  map[string]cacheCredentialEntry
 }
 
-func New(url []string, bindPattern []string, timeoutSecs uint, rootCAs *x509.CertPool, logger log.DebugLogger) (
+func New(url []string, bindPattern []string, timeoutSecs uint, rootCAs *x509.CertPool, storage simplestorage.SimpleStore, logger log.DebugLogger) (
 	*PasswordAuthenticator, error) {
-	return newAuthenticator(url, bindPattern, timeoutSecs, rootCAs, logger)
+	return newAuthenticator(url, bindPattern, timeoutSecs, rootCAs, storage, logger)
 }
 
 // PasswordAuthenticate will authenticate a user using the provided username and

--- a/lib/pwauth/ldap/impl.go
+++ b/lib/pwauth/ldap/impl.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/Symantec/Dominator/lib/log"
 	"github.com/Symantec/keymaster/lib/authutil"
+	"github.com/Symantec/keymaster/lib/simplestorage"
 )
 
 const defaultCacheDuration = time.Hour * 96
 
 func newAuthenticator(urllist []string, bindPattern []string,
-	timeoutSecs uint, rootCAs *x509.CertPool, logger log.DebugLogger) (
+	timeoutSecs uint, rootCAs *x509.CertPool,
+	storage simplestorage.SimpleStore, logger log.DebugLogger) (
 	*PasswordAuthenticator, error) {
 	var authenticator PasswordAuthenticator
 	for _, stringURL := range urllist {
@@ -28,6 +30,7 @@ func newAuthenticator(urllist []string, bindPattern []string,
 	authenticator.rootCAs = rootCAs
 	authenticator.logger = logger
 	authenticator.expirationDuration = defaultCacheDuration
+	authenticator.storage = storage
 	authenticator.cachedCredentials = make(map[string]cacheCredentialEntry)
 	return &authenticator, nil
 }

--- a/lib/pwauth/ldap/impl_test.go
+++ b/lib/pwauth/ldap/impl_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Symantec/keymaster/lib/simplestorage/memstore"
+
 	"github.com/vjeantet/ldapserver"
 )
 
@@ -233,7 +235,8 @@ func TestPasswordAuthetnicateCache(t *testing.T) {
 	if !ok {
 		t.Fatal("cannot add certs to certpool")
 	}
-	authn, err := newAuthenticator([]string{localLDAPSURL}, []string{"%s"}, 1, certPool, nil, nil)
+	cache := memstore.New()
+	authn, err := newAuthenticator([]string{localLDAPSURL}, []string{"%s"}, 1, certPool, cache, nil)
 	//ok, err := CheckHtpasswdUserPassword("username", "password", []byte(userdbContent))
 	if err != nil {
 		t.Fatal(err)

--- a/lib/pwauth/ldap/impl_test.go
+++ b/lib/pwauth/ldap/impl_test.go
@@ -169,12 +169,12 @@ func init() {
 		config, _ := getTLSconfig()
 		s.Listener = tls.NewListener(s.Listener, config)
 	}
-	go server.ListenAndServe(":10636", secureConn)
+	go server.ListenAndServe(":10638", secureConn)
 
 	//we also make a simple tls listener
 	//
 	config, _ := getTLSconfig()
-	ln, _ := tls.Listen("tcp", ":10637", config)
+	ln, _ := tls.Listen("tcp", ":10639", config)
 	go func(ln net.Listener) {
 		for {
 			conn, err := ln.Accept()
@@ -192,7 +192,7 @@ func init() {
 	time.Sleep(20 * time.Millisecond)
 }
 
-const localLDAPSURL = "ldaps://localhost:10636"
+const localLDAPSURL = "ldaps://localhost:10638"
 
 func TestPasswordAuthetnicateSimple(t *testing.T) {
 	certPool := x509.NewCertPool()

--- a/lib/pwauth/ldap/impl_test.go
+++ b/lib/pwauth/ldap/impl_test.go
@@ -198,7 +198,7 @@ func TestPasswordAuthetnicateSimple(t *testing.T) {
 	if !ok {
 		t.Fatal("cannot add certs to certpool")
 	}
-	authn, err := newAuthenticator([]string{localLDAPSURL}, []string{"%s"}, 0, certPool, nil)
+	authn, err := newAuthenticator([]string{localLDAPSURL}, []string{"%s"}, 0, certPool, nil, nil)
 	//ok, err := CheckHtpasswdUserPassword("username", "password", []byte(userdbContent))
 	if err != nil {
 		t.Fatal(err)
@@ -233,7 +233,7 @@ func TestPasswordAuthetnicateCache(t *testing.T) {
 	if !ok {
 		t.Fatal("cannot add certs to certpool")
 	}
-	authn, err := newAuthenticator([]string{localLDAPSURL}, []string{"%s"}, 1, certPool, nil)
+	authn, err := newAuthenticator([]string{localLDAPSURL}, []string{"%s"}, 1, certPool, nil, nil)
 	//ok, err := CheckHtpasswdUserPassword("username", "password", []byte(userdbContent))
 	if err != nil {
 		t.Fatal(err)

--- a/lib/simplestorage/api.go
+++ b/lib/simplestorage/api.go
@@ -1,0 +1,17 @@
+package simplestorage
+
+// Simple is an interface type that defines how to store, retrieve and
+// delete simple strings. Values are uniquely defined by the key and the type
+// The data MUST be signed if stored out of the memory space of the running process.
+// The data however is not required to be encrypted.
+type SimpleStore interface {
+	// Upsert will insert or update the data and expiration of a string
+	UpsertSigned(key string, dataType int, expiration int64, data string) error
+	// Deletes a value from the storage service
+	DeleteSigned(key string, dataType int) error
+	// Gets the value from the storage service if the value exists and
+	// is not expired will return true, the value and nill.
+	// if the value does not exist or is expired will return false, empty string
+	// and nil. Any other case is an error.
+	GetSigned(key string, dataType int) (bool, string, error)
+}

--- a/lib/simplestorage/memstore/memstore.go
+++ b/lib/simplestorage/memstore/memstore.go
@@ -1,0 +1,52 @@
+package memstore
+
+// This is a demo package.. please dont use except for testing of the
+// consumers of the SimpleStpre interface
+
+import (
+	"time"
+)
+
+type Index struct {
+	Key      string
+	DataType int
+}
+
+type MemDatum struct {
+	Data       string
+	Expiration int64
+}
+
+type MemStore struct {
+	mstore map[Index]MemDatum
+}
+
+func New() *MemStore {
+	var mstore MemStore
+	mstore.mstore = make(map[Index]MemDatum)
+	return &mstore
+}
+
+func (ms *MemStore) UpsertSigned(key string, dataType int, expiration int64, data string) error {
+	datum := MemDatum{Data: data, Expiration: expiration}
+	index := Index{Key: key, DataType: dataType}
+	ms.mstore[index] = datum
+	return nil
+}
+func (ms *MemStore) DeleteSigned(key string, dataType int) error {
+	index := Index{Key: key, DataType: dataType}
+	delete(ms.mstore, index)
+	return nil
+}
+func (ms *MemStore) GetSigned(key string, dataType int) (bool, string, error) {
+	index := Index{Key: key, DataType: dataType}
+	datum, ok := ms.mstore[index]
+	if !ok {
+		return false, "", nil
+	}
+	if datum.Expiration < time.Now().Unix() {
+		delete(ms.mstore, index)
+		return false, "", nil
+	}
+	return true, datum.Data, nil
+}


### PR DESCRIPTION
This make the cache to be stored in the databases and enhances the databases for an extra table to store such data. This will allow us to survive either AD or RDS to fail. Next change will add the copying into the cacheDB so that simultaneous ldap and RDS failures can be survived.