### PR TITLE
Connect to server before password ask cli part1

### DIFF
--- a/cmd/keymaster/main.go
+++ b/cmd/keymaster/main.go
@@ -109,7 +109,7 @@ func getUserNameAndHomeDir(logger log.Logger) (userName, homeDir string) {
 	return
 }
 
-func loadConfigFile(rootCAs *x509.CertPool, logger log.Logger) (
+func loadConfigFile(rootCAs *x509.CertPool, client *http.Client, logger log.Logger) (
 	configContents config.AppConfigFile) {
 	configPath, _ := filepath.Split(*configFilename)
 
@@ -119,15 +119,15 @@ func loadConfigFile(rootCAs *x509.CertPool, logger log.Logger) (
 	}
 
 	if len(*configHost) > 1 {
-		err = config.GetConfigFromHost(*configFilename, *configHost, rootCAs,
-			dialer, logger)
+		err = config.GetConfigFromHost(*configFilename, *configHost,
+			client, logger)
 		if err != nil {
 			logger.Fatal(err)
 		}
 	} else if len(defaultConfigHost) > 1 { // if there is a configHost AND there is NO config file, create one
 		if _, err := os.Stat(*configFilename); os.IsNotExist(err) {
 			err = config.GetConfigFromHost(
-				*configFilename, defaultConfigHost, rootCAs, dialer, logger)
+				*configFilename, defaultConfigHost, client, logger)
 			if err != nil {
 				logger.Fatal(err)
 			}
@@ -321,7 +321,7 @@ func main() {
 	computeUserAgent()
 
 	userName, homeDir := getUserNameAndHomeDir(logger)
-	config := loadConfigFile(rootCAs, logger)
+	config := loadConfigFile(rootCAs, client, logger)
 
 	// Adjust user name
 	if len(config.Base.Username) > 0 {

--- a/cmd/keymaster/main.go
+++ b/cmd/keymaster/main.go
@@ -53,7 +53,6 @@ var (
 		"If true, use the smart round-robin dialer")
 
 	FilePrefix = "keymaster"
-	dialer     libnet.Dialer
 )
 
 func getUserHomeDir() (homeDir string) {
@@ -278,6 +277,7 @@ func computeUserAgent() {
 }
 
 func getHttpClient(rootCAs *x509.CertPool, logger log.DebugLogger) (*http.Client, error) {
+	var dialer libnet.Dialer
 	rawDialer := &net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/cmd/keymaster/main.go
+++ b/cmd/keymaster/main.go
@@ -109,7 +109,7 @@ func getUserNameAndHomeDir(logger log.Logger) (userName, homeDir string) {
 	return
 }
 
-func loadConfigFile(rootCAs *x509.CertPool, client *http.Client, logger log.Logger) (
+func loadConfigFile(client *http.Client, logger log.Logger) (
 	configContents config.AppConfigFile) {
 	configPath, _ := filepath.Split(*configFilename)
 
@@ -293,7 +293,6 @@ func getHttpClient(rootCAs *x509.CertPool, logger log.DebugLogger) (*http.Client
 	} else {
 		dialer = rawDialer
 	}
-	//rootCAs := maybeGetRootCas(logger)
 	tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 	return util.GetHttpClient(tlsConfig, dialer)
 }
@@ -321,7 +320,7 @@ func main() {
 	computeUserAgent()
 
 	userName, homeDir := getUserNameAndHomeDir(logger)
-	config := loadConfigFile(rootCAs, client, logger)
+	config := loadConfigFile(client, logger)
 
 	// Adjust user name
 	if len(config.Base.Username) > 0 {

--- a/lib/client/config/api.go
+++ b/lib/client/config/api.go
@@ -1,10 +1,9 @@
 package config
 
 import (
-	"crypto/x509"
+	"net/http"
 
 	"github.com/Symantec/Dominator/lib/log"
-	"github.com/Symantec/keymaster/lib/client/net"
 )
 
 type BaseConfig struct {
@@ -31,8 +30,7 @@ func LoadVerifyConfigFile(configFilename string) (AppConfigFile, error) {
 func GetConfigFromHost(
 	configFilename string,
 	hostname string,
-	rootCAs *x509.CertPool,
-	dialer net.Dialer,
+	client *http.Client,
 	logger log.Logger) error {
-	return getConfigFromHost(configFilename, hostname, rootCAs, dialer, logger)
+	return getConfigFromHost(configFilename, hostname, client, logger)
 }

--- a/lib/client/config/config.go
+++ b/lib/client/config/config.go
@@ -1,15 +1,12 @@
 package config
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"io/ioutil"
+	"net/http"
 	"os"
 
 	"github.com/Symantec/Dominator/lib/log"
-	"github.com/Symantec/keymaster/lib/client/net"
-	"github.com/Symantec/keymaster/lib/client/util"
 	"gopkg.in/yaml.v2"
 )
 
@@ -44,21 +41,9 @@ const hostConfigPath = "/public/clientConfig"
 func getConfigFromHost(
 	configFilename string,
 	hostname string,
-	rootCAs *x509.CertPool,
-	dialer net.Dialer,
+	client *http.Client,
 	logger log.Logger) error {
-	tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
-	client, err := util.GetHttpClient(tlsConfig, dialer)
-	if err != nil {
-		return err
-	}
 	configUrl := "https://" + hostname + hostConfigPath
-	/*
-		        req, err := http.NewRequest("GET", configUrl, nil)
-				        if err != nil {
-								            return err
-											        }
-	*/
 	resp, err := client.Get(configUrl)
 	if err != nil {
 		logger.Printf("got error from req")

--- a/lib/client/twofa/api.go
+++ b/lib/client/twofa/api.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"flag"
+	"net/http"
 	"time"
 
 	"github.com/Symantec/Dominator/lib/log"
@@ -30,9 +31,10 @@ func GetCertFromTargetUrls(
 	skipu2f bool,
 	addGroups bool,
 	dialer net.Dialer,
+	client *http.Client,
 	userAgentString string,
 	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, kubernetesCert []byte, err error) {
 	return getCertFromTargetUrls(
-		signer, userName, password, targetUrls, rootCAs, skipu2f, addGroups,
-		dialer, userAgentString, logger)
+		signer, userName, password, targetUrls, skipu2f, addGroups,
+		client, userAgentString, logger)
 }

--- a/lib/client/twofa/api.go
+++ b/lib/client/twofa/api.go
@@ -3,13 +3,11 @@ package twofa
 
 import (
 	"crypto"
-	"crypto/x509"
 	"flag"
 	"net/http"
 	"time"
 
 	"github.com/Symantec/Dominator/lib/log"
-	"github.com/Symantec/keymaster/lib/client/net"
 )
 
 var (
@@ -27,10 +25,8 @@ func GetCertFromTargetUrls(
 	userName string,
 	password []byte,
 	targetUrls []string,
-	rootCAs *x509.CertPool,
 	skipu2f bool,
 	addGroups bool,
-	dialer net.Dialer,
 	client *http.Client,
 	userAgentString string,
 	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, kubernetesCert []byte, err error) {

--- a/lib/client/twofa/twofa.go
+++ b/lib/client/twofa/twofa.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Symantec/Dominator/lib/log"
 	"github.com/Symantec/keymaster/lib/client/twofa/u2f"
 	"github.com/Symantec/keymaster/lib/client/twofa/vip"
-	//"github.com/Symantec/keymaster/lib/client/util"
 	"github.com/Symantec/keymaster/lib/webapi/v0/proto"
 	"github.com/flynn/u2f/u2fhid" // client side (interface with hardware)
 	"golang.org/x/crypto/ssh"
@@ -102,14 +101,6 @@ func getCertsFromServer(
 	client *http.Client,
 	userAgentString string,
 	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, kubernetesCert []byte, err error) {
-
-	//First Do Login
-	/*
-		client, err := util.GetHttpClient(tlsConfig, dialer)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-	*/
 
 	loginUrl := baseUrl + proto.LoginPath
 	form := url.Values{}
@@ -297,7 +288,6 @@ func getCertFromTargetUrls(
 	userAgentString string,
 	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, kubernetesCert []byte, err error) {
 	success := false
-	//tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 
 	for _, baseUrl := range targetUrls {
 		logger.Printf("attempting to target '%s' for '%s'\n", baseUrl, userName)

--- a/lib/client/twofa/twofa.go
+++ b/lib/client/twofa/twofa.go
@@ -3,7 +3,6 @@ package twofa
 import (
 	"bytes"
 	"crypto"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -20,10 +19,9 @@ import (
 	"strings"
 
 	"github.com/Symantec/Dominator/lib/log"
-	"github.com/Symantec/keymaster/lib/client/net"
 	"github.com/Symantec/keymaster/lib/client/twofa/u2f"
 	"github.com/Symantec/keymaster/lib/client/twofa/vip"
-	"github.com/Symantec/keymaster/lib/client/util"
+	//"github.com/Symantec/keymaster/lib/client/util"
 	"github.com/Symantec/keymaster/lib/webapi/v0/proto"
 	"github.com/flynn/u2f/u2fhid" // client side (interface with hardware)
 	"golang.org/x/crypto/ssh"
@@ -99,18 +97,19 @@ func getCertsFromServer(
 	userName string,
 	password []byte,
 	baseUrl string,
-	tlsConfig *tls.Config,
 	skip2fa bool,
 	addGroups bool,
-	dialer net.Dialer,
+	client *http.Client,
 	userAgentString string,
 	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, kubernetesCert []byte, err error) {
 
 	//First Do Login
-	client, err := util.GetHttpClient(tlsConfig, dialer)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	/*
+		client, err := util.GetHttpClient(tlsConfig, dialer)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	*/
 
 	loginUrl := baseUrl + proto.LoginPath
 	form := url.Values{}
@@ -292,20 +291,19 @@ func getCertFromTargetUrls(
 	userName string,
 	password []byte,
 	targetUrls []string,
-	rootCAs *x509.CertPool,
 	skipu2f bool,
 	addGroups bool,
-	dialer net.Dialer,
+	client *http.Client,
 	userAgentString string,
 	logger log.DebugLogger) (sshCert []byte, x509Cert []byte, kubernetesCert []byte, err error) {
 	success := false
-	tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
+	//tlsConfig := &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12}
 
 	for _, baseUrl := range targetUrls {
 		logger.Printf("attempting to target '%s' for '%s'\n", baseUrl, userName)
 		sshCert, x509Cert, kubernetesCert, err = getCertsFromServer(
-			signer, userName, password, baseUrl, tlsConfig, skipu2f, addGroups,
-			dialer, userAgentString, logger)
+			signer, userName, password, baseUrl, skipu2f, addGroups,
+			client, userAgentString, logger)
 		if err != nil {
 			logger.Println(err)
 			continue

--- a/lib/client/twofa/twofa_test.go
+++ b/lib/client/twofa/twofa_test.go
@@ -149,6 +149,11 @@ func TestGetCertFromTargetUrlsSuccessOneURL(t *testing.T) {
 	if !ok {
 		t.Fatal("cannot add certs to certpool")
 	}
+	tlsConfig := &tls.Config{RootCAs: certPool, MinVersion: tls.VersionTLS12}
+	client, err := util.GetHttpClient(tlsConfig, &net.Dialer{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	privateKey, err := util.GenerateKey()
 	if err != nil {
 		t.Fatal(err)
@@ -159,10 +164,9 @@ func TestGetCertFromTargetUrlsSuccessOneURL(t *testing.T) {
 		"username",
 		[]byte("password"),
 		[]string{localHttpsTarget},
-		certPool,
 		skipu2f,
 		false,
-		&net.Dialer{},
+		client,
 		"someUserAgent",
 		testlogger.New(t)) //(cert []byte, err error)
 	if err != nil {
@@ -175,16 +179,20 @@ func TestGetCertFromTargetUrlsFailUntrustedCA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	client, err := util.GetHttpClient(tlsConfig, &net.Dialer{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	skipu2f := true
 	_, _, _, err = GetCertFromTargetUrls(
 		privateKey,
 		"username",
 		[]byte("password"),
 		[]string{localHttpsTarget},
-		nil,
 		skipu2f,
 		false,
-		&net.Dialer{},
+		client,
 		"someUserAgent",
 		testlogger.New(t))
 	if err == nil {


### PR DESCRIPTION
These patches refactor the keymaster cli client and libraries so that the use an http.Client. This will allow to pre-connect to the servers to enable a warning if the keymaster servers are unreachable before asking for the password.  